### PR TITLE
Fix bug that resulted in RMI not being OK

### DIFF
--- a/src/main/java/fr/inria/spirals/npefix/main/run/Main.java
+++ b/src/main/java/fr/inria/spirals/npefix/main/run/Main.java
@@ -98,9 +98,9 @@ public class Main {
 	}
 
 	private NPEOutput multipleRuns(Launcher  npefix, List<String> npeTests, Selector selector) {
-		List<String> testMethods = npefix.getTests(npeTests.toArray(new String[0]));
 		DecisionServer decisionServer = new DecisionServer(selector);
 		decisionServer.startServer();
+		List<String> testMethods = npefix.getTests(npeTests.toArray(new String[0]));
 
 		NPEOutput output = new NPEOutput();
 


### PR DESCRIPTION
This is mentioned in https://github.com/SpoonLabs/npefix/issues/24#issuecomment-739956097

This happened because `CallChecker`, that statically checks the RMI server, is called in the method `getTests` of `Launcher`, which was called before starting the RMI server.
